### PR TITLE
Add close file after the exception was thrown

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -34,6 +34,7 @@ int main()
                 }
             }catch(const char* msg) {
                 std::cerr << msg << std::endl;
+                input_file.close();
                 return 0;
             }
             graph.InsertEdge(temp_node_a, temp_node_b, temp_edge_weight, 0);


### PR DESCRIPTION
In the case of exception, file should be closed to clear the memory.